### PR TITLE
FuseCloud: fixup indentation in unoproj

### DIFF
--- a/FuseCloud/FuseCloud.unoproj
+++ b/FuseCloud/FuseCloud.unoproj
@@ -8,8 +8,8 @@
 	},
 	"Android": {
 		"SDK": {
-            "MinVersion": 21,
-        },
+			"MinVersion": 21,
+		},
 		"Description": "A music player made with Fuse, powered by SoundCloud®.",
 		"Package": "com.fuse.fusecloud",
 		"VersionCode": 3,


### PR DESCRIPTION
Two lines were space-indented rather than tab-indented, unlike the rest of this file. Fix it up!