### PR TITLE
use travis for continuous integration

### DIFF
--- a/.travis.xcconfig
+++ b/.travis.xcconfig
@@ -1,0 +1,1 @@
+SDKROOT = iphonesimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+osx_image: xcode8.1
+
+os:
+  - osx
+
+env:
+  global:
+    - XCODE_XCCONFIG_FILE=$TRAVIS_BUILD_DIR/.travis.xcconfig
+
+before_script:
+  - wget https://www.fusetools.com/downloads/latest/beta/osx -O fuse-installer.pkg &&
+    sudo installer -pkg fuse-installer.pkg -target /
+
+script:
+  - uno build -tios FuseCloud/FuseCloud.unoproj

--- a/FuseCloud/Pages/Comments/CommentsPage.ux
+++ b/FuseCloud/Pages/Comments/CommentsPage.ux
@@ -11,8 +11,7 @@
 	
 	<JavaScript File="../TrackPage/TrackDetails.js" />
 	<Router ux:Dependency="router"/>
-	<Page ux:Name="mainContent" Margin="10" ClipToBounds="True" Color="White"
-		Freeze="WhileNavigating">
+	<Page ux:Name="mainContent" Margin="10" ClipToBounds="True" Color="White">
 		<Panel Padding="15" Clicked="{goBack}" HitTestMode="LocalBounds" Alignment="TopRight">
 			<FuseCloud.CrossIcon Height="22" Width="22" Alignment="Center" CrossColor="DarkTextColor"/>
 

--- a/FuseCloud/Pages/TrackPage/TrackDetailsPage.ux
+++ b/FuseCloud/Pages/TrackPage/TrackDetailsPage.ux
@@ -1,5 +1,4 @@
-<Page ux:Class="FuseCloud.TrackDetailsPage" Color="#000" Transition="None" ClipToBounds="true"
-	Freeze="WhileNavigating">
+<Page ux:Class="FuseCloud.TrackDetailsPage" Color="#000" Transition="None" ClipToBounds="true">
 	
 	<StatusBarBackground Row="0"/>
 	

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FuseCloud
 
+[![Build Status](https://travis-ci.org/fusetools/FuseCloud.svg?branch=master)](https://travis-ci.org/fusetools/FuseCloud)
+
 FuseCloud is a cross-platform music player that interacts with the SoundCloud<sup>®</sup> API, made with [Fuse](https://www.fusetools.com).
 It allows you to log in with your SoundCloud<sup>®</sup> user account and listen to your favorite tracks as well as discover new music through a news feed and conventional search.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ The app can be downloaded for both Android and iOS throug the [AppStore](https:/
 
 We've written about the motivation behind this project in [this medium article](https://medium.com/@fusetools/i-made-a-cross-platform-soundcloud-player-with-fuse-9fb1e62b7db1#.lhu76dfj6).
 
-## Branches
-
-This app uses features from an unreleased version of Fuse.
-Please use the `for-fuse-0.31`-branch to run this app with the currently released version of Fuse.
-
 ## Setup
 
 Register your app at https://soundcloud.com/you/apps. Assign a custom redirect uri to let SoundCloud<sup>®</sup> know how to route back to the app after the user has logged in. We chose fuse-soundcloud://fuse for our app, but you'll need to come up with a new one.


### PR DESCRIPTION
This uses travis-ci for continuous integration, so we notice breakages more easily.

Only iOS builds are enabled for now. Android is a bit more tricky, as we need to install SDK and NDK.